### PR TITLE
add ethermint feature to the root package

### DIFF
--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -40,5 +40,15 @@ register_delegate_keys = { path = "./register_delegate_keys" }
 gorc = { path = "./gorc" }
 relayer = { path = "./relayer" }
 
+[features]
+ethermint = [
+    "orchestrator/ethermint",
+    "cosmos_gravity/ethermint",
+    "relayer/ethermint",
+    "gorc/ethermint",
+    "register_delegate_keys/ethermint",
+    "client/ethermint",
+]
+
 [patch.crates-io]
 deep_space = { git = "https://github.com/crypto-org-chain/deep_space/", branch = "ethermint" }


### PR DESCRIPTION
This is needed to run `cargo -p gorc --features ethermint` in the workspace directory, which is necessary for the nix `buildRustPackage`.