### PR TITLE
Add ETH gravity wrapper

### DIFF
--- a/solidity/contracts/EthGravityWrapper.sol
+++ b/solidity/contracts/EthGravityWrapper.sol
@@ -5,10 +5,9 @@ import "@uniswap/v2-periphery/contracts/interfaces/IWETH.sol";
 import "./Gravity.sol";
 
 contract EthGravityWrapper {
-	address WETH_ADDRESS;
-	address GRAVITY_ADDRESS;
-
-	uint256 MAX_VALUE = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+	address immutable WETH_ADDRESS;
+	address immutable GRAVITY_ADDRESS;
+	uint256 constant MAX_VALUE = uint(-1);
 
 	event SendToCosmosEthEvent(
 		address indexed _sender,
@@ -19,8 +18,8 @@ contract EthGravityWrapper {
 	constructor(address _wethAddress, address _gravityAddress) public {
 		WETH_ADDRESS = _wethAddress;
 		GRAVITY_ADDRESS = _gravityAddress;
-
-		IERC20(WETH_ADDRESS).approve(GRAVITY_ADDRESS, MAX_VALUE);
+ 
+		IERC20(_wethAddress).approve(_gravityAddress, MAX_VALUE);
 	}
 
 	function sendToCosmosEth(bytes32 _destination) public payable {

--- a/solidity/contracts/EthGravityWrapper.sol
+++ b/solidity/contracts/EthGravityWrapper.sol
@@ -7,7 +7,7 @@ import "./Gravity.sol";
 contract EthGravityWrapper {
 	address immutable WETH_ADDRESS;
 	address immutable GRAVITY_ADDRESS;
-	uint256 constant MAX_VALUE = uint(-1);
+	uint256 constant MAX_VALUE = uint256(-1);
 
 	event SendToCosmosEthEvent(
 		address indexed _sender,

--- a/solidity/contracts/EthGravityWrapper.sol
+++ b/solidity/contracts/EthGravityWrapper.sol
@@ -1,0 +1,35 @@
+pragma solidity ^0.6.6;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@uniswap/v2-periphery/contracts/interfaces/IWETH.sol";
+import "./Gravity.sol";
+
+contract EthGravityWrapper {
+	address WETH_ADDRESS;
+	address GRAVITY_ADDRESS;
+
+	uint256 MAX_VALUE = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+
+	event SendToCosmosEthEvent(
+		address indexed _sender,
+		bytes32 indexed _destination,
+		uint256 _amount
+	);
+
+	constructor(address _wethAddress, address _gravityAddress) public {
+		WETH_ADDRESS = _wethAddress;
+		GRAVITY_ADDRESS = _gravityAddress;
+
+		IERC20(WETH_ADDRESS).approve(GRAVITY_ADDRESS, MAX_VALUE);
+	}
+
+	function sendToCosmosEth(bytes32 _destination) public payable {
+		uint256 amount = msg.value;
+		require(amount > 0, "Amount should be greater than 0");
+
+		IWETH(WETH_ADDRESS).deposit{ value: amount }();
+		Gravity(GRAVITY_ADDRESS).sendToCosmos(WETH_ADDRESS, _destination, amount);
+
+		emit SendToCosmosEthEvent(msg.sender, _destination, amount);
+	}
+}

--- a/solidity/contracts/TestWETH.sol
+++ b/solidity/contracts/TestWETH.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.6.6;
+
+import "@uniswap/v2-periphery/contracts/test/WETH9.sol";
+
+// Testing contract for WETH
+contract TestWETH is WETH9 {
+	
+}

--- a/solidity/test/ethGravityWrapper.ts
+++ b/solidity/test/ethGravityWrapper.ts
@@ -1,0 +1,122 @@
+import chai from "chai";
+import { ethers } from "hardhat";
+import { solidity } from "ethereum-waffle";
+import { TestWETH } from "../typechain/TestWETH";
+import { EthGravityWrapper } from "../typechain/EthGravityWrapper";
+
+import { deployContracts } from "../test-utils";
+import { examplePowers } from "../test-utils/pure";
+import { Gravity } from "../typechain";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+chai.use(solidity);
+const { expect } = chai;
+
+describe("EthGravityWrapper tests", function () {
+  let testWETH: TestWETH;
+  let gravity: Gravity;
+  let ethGravityWrapper: EthGravityWrapper;
+  let signers: SignerWithAddress[];
+
+  beforeEach(async () => {
+    // Prep and deploy WETH
+    const TestWETH = await ethers.getContractFactory("TestWETH");
+    testWETH = (await TestWETH.deploy()) as TestWETH;
+
+    // Prep and deploy contract Gravity
+    signers = await ethers.getSigners();
+    const gravityId = ethers.utils.formatBytes32String("foo");
+    // This is the power distribution on the Cosmos hub as of 7/14/2020
+    const powers = examplePowers();
+    const validators = signers.slice(0, powers.length);
+    const powerThreshold = 6666;
+    ({ gravity } = await deployContracts(
+      gravityId,
+      validators,
+      powers,
+      powerThreshold
+    ));
+
+    // Prep and deploy contract EthGravityWrapper
+    const EthGravityWrapper = await ethers.getContractFactory(
+      "EthGravityWrapper"
+    );
+    ethGravityWrapper = (await EthGravityWrapper.deploy(
+      testWETH.address,
+      gravity.address
+    )) as EthGravityWrapper;
+  });
+
+  it("allow eth to be sent", async function () {
+    // Check balance before on Gravity.sol
+    expect((await testWETH.functions.balanceOf(gravity.address))[0]).to.equal(
+      0
+    );
+
+    // Sending ETH over
+    await testWETH.functions.approve(gravity.address, 100);
+    await expect(
+      ethGravityWrapper.functions.sendToCosmosEth(
+        ethers.utils.formatBytes32String("myCosmosAddress"),
+        {
+          value: "100",
+        }
+      )
+    )
+      .to.emit(ethGravityWrapper, "SendToCosmosEthEvent")
+      .withArgs(
+        await signers[0].getAddress,
+        ethers.utils.formatBytes32String("myCosmosAddress"),
+        100
+      );
+
+    // Check balance after on Gravity.sol
+    expect(
+      (await testWETH.functions.balanceOf(ethGravityWrapper.address))[0]
+    ).to.equal(0);
+    expect((await testWETH.functions.balanceOf(gravity.address))[0]).to.equal(
+      100
+    );
+  });
+
+  it("does not reduce WETH allowance for gravity", async function () {
+    const allowancePrior = await testWETH.allowance(
+      ethGravityWrapper.address,
+      gravity.address
+    );
+
+    // Sending ETH over
+    await testWETH.functions.approve(gravity.address, 10000000);
+    await ethGravityWrapper.functions.sendToCosmosEth(
+      ethers.utils.formatBytes32String("myCosmosAddress"),
+      {
+        value: "10000000",
+      }
+    );
+
+    const allowanceAfter = await testWETH.allowance(
+      ethGravityWrapper.address,
+      gravity.address
+    );
+    expect(allowancePrior.toString()).to.equals(allowanceAfter.toString());
+  });
+
+  it("checks for eth amount > 0", async function () {
+    // Check balance before on Gravity.sol
+    expect((await testWETH.functions.balanceOf(gravity.address))[0]).to.equal(
+      0
+    );
+
+    // Sending ETH over with 0 value
+    await testWETH.functions.approve(gravity.address, 100);
+    await expect(
+      ethGravityWrapper.functions.sendToCosmosEth(
+        ethers.utils.formatBytes32String("myCosmosAddress")
+      )
+    ).to.be.revertedWith("Amount should be greater than 0");
+
+    // Check balance after on Gravity.sol
+    expect((await testWETH.functions.balanceOf(gravity.address))[0]).to.equal(
+      0
+    );
+  });
+});

--- a/solidity/test/ethGravityWrapper.ts
+++ b/solidity/test/ethGravityWrapper.ts
@@ -46,7 +46,7 @@ describe("EthGravityWrapper tests", function () {
     )) as EthGravityWrapper;
   });
 
-  it("allow eth to be sent", async function () {
+  it("allows eth to be sent", async function () {
     // Check balance before on Gravity.sol
     expect((await testWETH.functions.balanceOf(gravity.address))[0]).to.equal(
       0


### PR DESCRIPTION
**Context**

`Gravity.sol` only accepts `ERC20` tokens and the requirement is to have a contract to wrap ETH <> WETH before calling `Gravity.sol` 

What this mean is that the bridge would call `EthGravityWrapper` if user selected `eth` or `Gravity` if user selected `erc20` token 