### PR TITLE
Problem: recipient type in sendToCosmos is confusing

### DIFF
--- a/solidity/contracts/Gravity.sol
+++ b/solidity/contracts/Gravity.sol
@@ -521,11 +521,19 @@ contract Gravity is ReentrancyGuard {
 		}
 	}
 
+	function sendToCronos(
+		address _tokenContract,
+		address _destination,
+		uint256 _amount
+	) public nonReentrant {
+		sendToCosmos(_tokenContract, bytes32(uint256(uint160(_destination))), _amount);
+	}
+
 	function sendToCosmos(
 		address _tokenContract,
 		bytes32 _destination,
 		uint256 _amount
-	) public nonReentrant {
+	) private {
 		IERC20(_tokenContract).safeTransferFrom(msg.sender, address(this), _amount);
 		state_lastEventNonce = state_lastEventNonce.add(1);
 		emit SendToCosmosEvent(


### PR DESCRIPTION
Solution:
- add a sendToCronos method which accept recipient in address type

it's tested in cronos's integration test: https://github.com/crypto-org-chain/cronos/pull/127