### PR TITLE
Tweak EthGravityWrapper syntax

### DIFF
--- a/solidity/contracts/EthGravityWrapper.sol
+++ b/solidity/contracts/EthGravityWrapper.sol
@@ -1,12 +1,16 @@
 pragma solidity ^0.6.6;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@uniswap/v2-periphery/contracts/interfaces/IWETH.sol";
 import "./Gravity.sol";
 
+interface IWETH {
+	function deposit() external payable;
+	function approve(address spender, uint256 amount) external;
+}
+
 contract EthGravityWrapper {
-	address immutable WETH_ADDRESS;
-	address immutable GRAVITY_ADDRESS;
+	IWETH public immutable weth;
+	Gravity public immutable gravity;
+
 	uint256 constant MAX_VALUE = uint256(-1);
 
 	event SendToCosmosEthEvent(
@@ -16,18 +20,18 @@ contract EthGravityWrapper {
 	);
 
 	constructor(address _wethAddress, address _gravityAddress) public {
-		WETH_ADDRESS = _wethAddress;
-		GRAVITY_ADDRESS = _gravityAddress;
- 
-		IERC20(_wethAddress).approve(_gravityAddress, MAX_VALUE);
+		weth = IWETH(_wethAddress);
+		gravity = Gravity(_gravityAddress);
+
+		IWETH(_wethAddress).approve(_gravityAddress, MAX_VALUE);
 	}
 
 	function sendToCosmosEth(bytes32 _destination) public payable {
 		uint256 amount = msg.value;
 		require(amount > 0, "Amount should be greater than 0");
 
-		IWETH(WETH_ADDRESS).deposit{ value: amount }();
-		Gravity(GRAVITY_ADDRESS).sendToCosmos(WETH_ADDRESS, _destination, amount);
+		weth.deposit{ value: amount }();
+		gravity.sendToCosmos(address(weth), _destination, amount);
 
 		emit SendToCosmosEthEvent(msg.sender, _destination, amount);
 	}

--- a/solidity/contracts/EthGravityWrapper.sol
+++ b/solidity/contracts/EthGravityWrapper.sol
@@ -13,9 +13,9 @@ contract EthGravityWrapper {
 
 	uint256 constant MAX_VALUE = uint256(-1);
 
-	event SendToCosmosEthEvent(
+	event sendToCronosEthEvent(
 		address indexed _sender,
-		bytes32 indexed _destination,
+		address indexed _destination,
 		uint256 _amount
 	);
 
@@ -26,13 +26,13 @@ contract EthGravityWrapper {
 		IWETH(_wethAddress).approve(_gravityAddress, MAX_VALUE);
 	}
 
-	function sendToCosmosEth(bytes32 _destination) public payable {
+	function sendToCronosEth(address _destination) public payable {
 		uint256 amount = msg.value;
 		require(amount > 0, "Amount should be greater than 0");
 
 		weth.deposit{ value: amount }();
-		gravity.sendToCosmos(address(weth), _destination, amount);
+		gravity.sendToCronos(address(weth), _destination, amount);
 
-		emit SendToCosmosEthEvent(msg.sender, _destination, amount);
+		emit sendToCronosEthEvent(msg.sender, _destination, amount);
 	}
 }

--- a/solidity/test/ethGravityWrapper.ts
+++ b/solidity/test/ethGravityWrapper.ts
@@ -47,6 +47,8 @@ describe("EthGravityWrapper tests", function () {
   });
 
   it("allows eth to be sent", async function () {
+    const destination = await signers[1].getAddress();
+
     // Check balance before on Gravity.sol
     expect((await testWETH.functions.balanceOf(gravity.address))[0]).to.equal(
       0
@@ -55,19 +57,12 @@ describe("EthGravityWrapper tests", function () {
     // Sending ETH over
     await testWETH.functions.approve(gravity.address, 100);
     await expect(
-      ethGravityWrapper.functions.sendToCosmosEth(
-        ethers.utils.formatBytes32String("myCosmosAddress"),
-        {
-          value: "100",
-        }
-      )
+      ethGravityWrapper.functions.sendToCronosEth(destination, {
+        value: "100",
+      })
     )
-      .to.emit(ethGravityWrapper, "SendToCosmosEthEvent")
-      .withArgs(
-        await signers[0].getAddress,
-        ethers.utils.formatBytes32String("myCosmosAddress"),
-        100
-      );
+      .to.emit(ethGravityWrapper, "sendToCronosEthEvent")
+      .withArgs(await signers[0].getAddress, destination, 100);
 
     // Check balance after on Gravity.sol
     expect(
@@ -79,6 +74,8 @@ describe("EthGravityWrapper tests", function () {
   });
 
   it("does not reduce WETH allowance for gravity", async function () {
+    const destination = await signers[1].getAddress();
+
     const allowancePrior = await testWETH.allowance(
       ethGravityWrapper.address,
       gravity.address
@@ -86,12 +83,9 @@ describe("EthGravityWrapper tests", function () {
 
     // Sending ETH over
     await testWETH.functions.approve(gravity.address, 10000000);
-    await ethGravityWrapper.functions.sendToCosmosEth(
-      ethers.utils.formatBytes32String("myCosmosAddress"),
-      {
-        value: "10000000",
-      }
-    );
+    await ethGravityWrapper.functions.sendToCronosEth(destination, {
+      value: "10000000",
+    });
 
     const allowanceAfter = await testWETH.allowance(
       ethGravityWrapper.address,
@@ -101,6 +95,8 @@ describe("EthGravityWrapper tests", function () {
   });
 
   it("checks for eth amount > 0", async function () {
+    const destination = await signers[1].getAddress();
+
     // Check balance before on Gravity.sol
     expect((await testWETH.functions.balanceOf(gravity.address))[0]).to.equal(
       0
@@ -109,9 +105,7 @@ describe("EthGravityWrapper tests", function () {
     // Sending ETH over with 0 value
     await testWETH.functions.approve(gravity.address, 100);
     await expect(
-      ethGravityWrapper.functions.sendToCosmosEth(
-        ethers.utils.formatBytes32String("myCosmosAddress")
-      )
+      ethGravityWrapper.functions.sendToCronosEth(destination)
     ).to.be.revertedWith("Amount should be greater than 0");
 
     // Check balance after on Gravity.sol


### PR DESCRIPTION
As discussed with Franco, syntax changes

1. made address variable public 
2. use contract instance over address for cleaner syntax
3. update per #8 to use `sendToCronos` 