### PR TITLE
Problem: processEthereumEvent does not persist hooks emitted event

### DIFF
--- a/module/x/gravity/keeper/ethereum_event_vote.go
+++ b/module/x/gravity/keeper/ethereum_event_vote.go
@@ -130,7 +130,8 @@ func (k Keeper) processEthereumEvent(ctx sdk.Context, event types.EthereumEvent)
 			"nonce", fmt.Sprint(event.GetEventNonce()),
 		)
 	} else {
-		commit() // persist transient storage
+		ctx.EventManager().EmitEvents(xCtx.EventManager().Events()) // copy events to original context
+		commit()                                                    // persist transient storage
 	}
 }
 


### PR DESCRIPTION
Solution: Copy events from cached context to persistance storage

-----

This is a port of the PR by @thomas-nguy on upstream (https://github.com/PeggyJV/gravity-bridge/pull/218), since the event emitted inside hook is necessary for our use cases, I am opening this PR so that we can have the fix earlier.

Since this only change the events being emitted, does it mean it is not consensus breaking changes?