### PR TITLE
Problem: keystore enum cannot be deserialized from config file

### DIFF
--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -1709,6 +1709,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deep_space"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,6 +2573,7 @@ dependencies = [
  "relayer",
  "rpassword",
  "serde",
+ "serde-enum-str",
  "signatory",
  "thiserror",
  "tokio 1.13.0",
@@ -4616,6 +4651,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-attributes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aba2af3c3b9cd6f3a919056dac6005b71fceecc1cdfa65c4df3912f64e07e60"
+dependencies = [
+ "darling_core",
+ "serde-rename-rule",
+ "syn",
+]
+
+[[package]]
 name = "serde-aux"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4624,6 +4670,25 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "serde-enum-str"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a41bf2fc78a58589b9a6948bfc918c9b2dc918732f2ac14eed982ffb876b39"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde-attributes",
+ "syn",
+]
+
+[[package]]
+name = "serde-rename-rule"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2930103714ccef4f1fe5b6a5f2b6fdcfe462a6c802464714bd41e5b5097c33"
 
 [[package]]
 name = "serde-rlp"

--- a/orchestrator/gorc/Cargo.toml
+++ b/orchestrator/gorc/Cargo.toml
@@ -10,6 +10,7 @@ aws-config = "0.4"
 aws-sdk-secretsmanager = "0.4"
 clap = "3"
 serde = { version = "1", features = ["serde_derive"] }
+serde-enum-str = "0.2.5"
 thiserror = "1"
 regex = "1.5.4"
 

--- a/orchestrator/gorc/src/config.rs
+++ b/orchestrator/gorc/src/config.rs
@@ -2,15 +2,17 @@ use cosmos_gravity::crypto::DEFAULT_HD_PATH;
 use ethers::signers::LocalWallet as EthWallet;
 use aws_sdk_secretsmanager::client::Client;
 use serde::{Deserialize, Serialize};
+use serde_enum_str::{Deserialize_enum_str, Serialize_enum_str};
 use signatory::FsKeyStore;
 use std::io;
 use std::net::SocketAddr;
 use std::path::Path;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize_enum_str, Serialize_enum_str)]
 pub enum Keystore {
-    File(String),
     Aws,
+    #[serde(other)]
+    File(String),
 }
 
 impl Default for Keystore {


### PR DESCRIPTION
Current code cannot deserialize the Keystore enum in configuration file.


I have tried the following 
```
"keystore" : 
   "File" : {Path}
```  

but it returns an error.


By using serde_enum_str , any string which is not "Aws" will be mapped to Keystore::File type

Possible value will be 
```
"keystore" : "Aws" 
or 
"keystore" : String
```