### PR TITLE
Add relayer command to gorc

### DIFF
--- a/orchestrator/gorc/README.md
+++ b/orchestrator/gorc/README.md
@@ -17,7 +17,8 @@ The `Gorc` application is still under development. This is a comprehensive docum
 | eth-to-cosmos     | This command, send Ethereum to Cosmos                       |
 | help              | Help command to get usage information                       |
 | keys              | Key management commands for Ethereum and Cosmos             |
-| orchestrator      | Management commannds for the orchestrator                   |
+| orchestrator      | Management commands for the orchestrator                    |
+| relayer           | Management commands for the relayer                         |
 | print-config      | Command for printing configurations                         |
 | query             | Command to query state on either ethereum or cosmos chains  |
 | sign-delegate-keys| Sign delegate keys command                                  |
@@ -112,6 +113,12 @@ The `keys` command takes the following argument/flags;
 
 ```
 gorc orchestrator start
+```
+
+**relayer:** To start the relayer, run the command below:
+
+```
+gorc relayer start
 ```
 
 **print-config:** To print the config file in your console, run the command below.

--- a/orchestrator/gorc/src/commands.rs
+++ b/orchestrator/gorc/src/commands.rs
@@ -6,6 +6,7 @@ mod deploy;
 mod eth_to_cosmos;
 mod keys;
 mod orchestrator;
+mod relayer;
 mod print_config;
 mod query;
 mod sign_delegate_keys;
@@ -34,6 +35,9 @@ pub enum GorcCmd {
 
     #[clap(subcommand)]
     Orchestrator(orchestrator::OrchestratorCmd),
+
+    #[clap(subcommand)]
+    Relayer(relayer::RelayerCmd),
 
     PrintConfig(print_config::PrintConfigCmd),
 

--- a/orchestrator/gorc/src/commands/relayer.rs
+++ b/orchestrator/gorc/src/commands/relayer.rs
@@ -1,0 +1,9 @@
+mod start;
+
+use abscissa_core::{clap::Parser, Command, Runnable};
+
+/// Management commands for the relayer
+#[derive(Command, Debug, Parser, Runnable)]
+pub enum RelayerCmd {
+    Start(start::StartCommand),
+}

--- a/orchestrator/gorc/src/commands/relayer/start.rs
+++ b/orchestrator/gorc/src/commands/relayer/start.rs
@@ -1,0 +1,87 @@
+use crate::{application::APP, prelude::*};
+use abscissa_core::{clap::Parser, Command, Runnable};
+use ethers::{prelude::*, types::Address as EthAddress};
+use gravity_utils::{
+    connection_prep::{
+        check_for_eth, create_rpc_connections,
+        wait_for_cosmos_node_ready,
+    },
+    ethereum::{downcast_to_u64, format_eth_address},
+};
+use relayer::main_loop::{
+    relayer_main_loop, LOOP_SPEED as RELAYER_LOOP_SPEED
+};
+use std::sync::Arc;
+
+/// Start the relayer
+#[derive(Command, Debug, Parser)]
+pub struct StartCommand {
+    #[clap(short, long)]
+    ethereum_key: String,
+}
+
+impl Runnable for StartCommand {
+    fn run(&self) {
+        openssl_probe::init_ssl_cert_env_vars();
+
+        let config = APP.config();
+        let cosmos_prefix = config.cosmos.prefix.clone();
+
+        let ethereum_wallet = config.load_ethers_wallet(self.ethereum_key.clone());
+        let ethereum_address = ethereum_wallet.address();
+
+        let contract_address: EthAddress = config
+            .gravity
+            .contract
+            .parse()
+            .expect("Could not parse gravity contract address");
+
+        let timeout = RELAYER_LOOP_SPEED;
+
+
+        abscissa_tokio::run_with_actix(&APP, async {
+            let connections = create_rpc_connections(
+                cosmos_prefix,
+                Some(config.cosmos.grpc.clone()),
+                Some(config.ethereum.rpc.clone()),
+                timeout,
+            )
+            .await;
+
+            let grpc = connections.grpc.clone().unwrap();
+            let contact = connections.contact.clone().unwrap();
+            let provider = connections.eth_provider.clone().unwrap();
+            let chain_id = provider
+                .get_chainid()
+                .await
+                .expect("Could not retrieve chain ID during relayer start");
+            let chain_id =
+                downcast_to_u64(chain_id).expect("Chain ID overflowed when downcasting to u64");
+            let eth_client =
+                SignerMiddleware::new(provider, ethereum_wallet.clone().with_chain_id(chain_id));
+            let eth_client = Arc::new(eth_client);
+
+            info!("Starting Relayer");
+            info!("Ethereum Address: {}", format_eth_address(ethereum_address));
+
+            // check if the cosmos node is syncing, if so wait for it
+            // we can't move any steps above this because they may fail on an incorrect
+            // historic chain state while syncing occurs
+            wait_for_cosmos_node_ready(&contact).await;
+            check_for_eth(ethereum_address, eth_client.clone()).await;
+            relayer_main_loop(
+                eth_client,
+                grpc,
+                contract_address,
+                config.ethereum.gas_price_multiplier,
+            )
+                .await;
+
+
+        })
+        .unwrap_or_else(|e| {
+            status_err!("executor exited with error: {}", e);
+            std::process::exit(1);
+        });
+    }
+}

--- a/orchestrator/gorc/src/config.rs
+++ b/orchestrator/gorc/src/config.rs
@@ -92,7 +92,7 @@ impl Keystore {
             Keystore::File(path) => {
                 let keystore = Path::new(path);
                 let keystore = FsKeyStore::create_or_open(keystore)?;
-                keystore.load(&name)
+                keystore.load(name)
             }
             Keystore::Aws => {
                 let rt = tokio::runtime::Runtime::new()?;
@@ -109,7 +109,7 @@ impl Keystore {
             Keystore::File(path) => {
                 let keystore = Path::new(path);
                 let keystore = FsKeyStore::create_or_open(keystore)?;
-                keystore.info(&name)
+                keystore.info(name)
             }
             Keystore::Aws => {
                 let rt = tokio::runtime::Runtime::new()?;
@@ -129,7 +129,7 @@ impl Keystore {
             Keystore::File(path) => {
                 let keystore = Path::new(path);
                 let keystore = FsKeyStore::create_or_open(keystore)?;
-                keystore.store(&name, der)
+                keystore.store(name, der)
             }
             Keystore::Aws => {
                 let rt = tokio::runtime::Runtime::new()?;
@@ -146,7 +146,7 @@ impl Keystore {
             Keystore::File(path) => {
                 let keystore = Path::new(path);
                 let keystore = FsKeyStore::create_or_open(keystore)?;
-                keystore.delete(&name)
+                keystore.delete(name)
             }
             Keystore::Aws => {
                 let rt = tokio::runtime::Runtime::new()?;


### PR DESCRIPTION
Add relayer commands to gorc 

While it is possible already to run the relayer using the relayer binary directly, adding this feature to gorc allows to :

- simplify the distribution of the binary to validators/partners. With gorc, it is possible to either run the "orchestrator", the "orchestrator + relayer" or  just the "relayer" 
- gorc can handle key management using keystore file or aws 