### PR TITLE
Problem: erc20 metadata check expect name instead of symbol

### DIFF
--- a/integration_tests/setup_test.go
+++ b/integration_tests/setup_test.go
@@ -263,6 +263,7 @@ func (s *IntegrationTestSuite) initGenesis() {
 		Display:     testDenom,
 		Base:        testDenom,
 		Name:        testDenom,
+		Symbol:      testDenom,
 		DenomUnits: []*banktypes.DenomUnit{
 			{
 				Denom:    testDenom,

--- a/module/cmd/gravity/cmd/root_test.go
+++ b/module/cmd/gravity/cmd/root_test.go
@@ -44,7 +44,7 @@ func TestKeyGen(t *testing.T) {
 		"orch",
 	})
 	keyCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		return 	client.SetCmdClientContextHandler(initClientCtx, keyCmd)
+		return client.SetCmdClientContextHandler(initClientCtx, keyCmd)
 	}
 	keyCmd.SetIn(input)
 

--- a/module/x/gravity/cosmos_originated_test.go
+++ b/module/x/gravity/cosmos_originated_test.go
@@ -70,6 +70,8 @@ func addDenomToERC20Relation(tv *testingVars) {
 		},
 		Base:    "uatom",
 		Display: "atom",
+		Name:    "Cosmos Token",
+		Symbol:  "ATOM",
 	})
 
 	var myNonce = uint64(1)
@@ -77,8 +79,8 @@ func addDenomToERC20Relation(tv *testingVars) {
 	deployedEvent := &types.ERC20DeployedEvent{
 		CosmosDenom:   tv.denom,
 		TokenContract: tv.erc20,
-		Erc20Name:     "atom",
-		Erc20Symbol:   "atom",
+		Erc20Name:     "Cosmos Token",
+		Erc20Symbol:   "ATOM",
 		Erc20Decimals: 6,
 		EventNonce:    myNonce,
 	}

--- a/module/x/gravity/keeper/ethereum_event_handler.go
+++ b/module/x/gravity/keeper/ethereum_event_handler.go
@@ -146,17 +146,17 @@ func (k Keeper) verifyERC20DeployedEvent(ctx sdk.Context, event *types.ERC20Depl
 }
 
 func verifyERC20Token(metadata banktypes.Metadata, event *types.ERC20DeployedEvent) error {
-	if event.Erc20Name != metadata.Display {
+	if event.Erc20Name != metadata.Name {
 		return sdkerrors.Wrapf(
 			types.ErrInvalidERC20Event,
-			"ERC20 name %s does not match the denom display %s", event.Erc20Name, metadata.Display,
+			"ERC20 name %s does not match the denom name %s", event.Erc20Name, metadata.Name,
 		)
 	}
 
-	if event.Erc20Symbol != metadata.Display {
+	if event.Erc20Symbol != metadata.Symbol {
 		return sdkerrors.Wrapf(
 			types.ErrInvalidERC20Event,
-			"ERC20 symbol %s does not match denom display %s", event.Erc20Symbol, metadata.Display,
+			"ERC20 symbol %s does not match denom symbol %s", event.Erc20Symbol, metadata.Symbol,
 		)
 	}
 

--- a/module/x/gravity/keeper/grpc_query.go
+++ b/module/x/gravity/keeper/grpc_query.go
@@ -327,12 +327,21 @@ func (k Keeper) DenomToERC20Params(c context.Context, req *types.DenomToERC20Par
 			}
 		}
 
-		return &types.DenomToERC20ParamsResponse{
+		resp := &types.DenomToERC20ParamsResponse{
 			BaseDenom:     md.Base,
-			Erc20Name:     md.Display,
-			Erc20Symbol:   md.Display,
+			Erc20Name:     md.Name,
+			Erc20Symbol:   md.Symbol,
 			Erc20Decimals: erc20Decimals,
-		}, nil
+		}
+
+		if resp.Erc20Name == "" {
+			resp.Erc20Name = md.Display
+		}
+		if resp.Erc20Symbol == "" {
+			resp.Erc20Symbol = md.Display
+		}
+
+		return resp, nil
 	}
 
 	if supply := k.bankKeeper.GetSupply(ctx, req.Denom); supply.IsZero() {

--- a/testnet/genesis.go
+++ b/testnet/genesis.go
@@ -24,6 +24,8 @@ type DenomMetadata struct {
 	Description string      `json:"description"`
 	Display     string      `json:"display"`
 	Base        string      `json:"base"`
+	Name        string      `json:"name"`
+	Symbol      string      `json:"symbol"`
 	DenomUnits  []DenomUnit `json:"denom_units"`
 }
 

--- a/testnet/with_pristine_e2e_environment_test.go
+++ b/testnet/with_pristine_e2e_environment_test.go
@@ -105,6 +105,8 @@ func withPristineE2EEnvironment(t *testing.T, cb func(
 		Description: "footoken",
 		Display:     "mfootoken",
 		Base:        "footoken",
+		Name:        "mfootoken",
+		Symbol:      "mfootoken",
 		DenomUnits: []DenomUnit{
 			{
 				Denom:    "footoken",
@@ -120,6 +122,8 @@ func withPristineE2EEnvironment(t *testing.T, cb func(
 		Description: "stake",
 		Display:     "mstake",
 		Base:        "stake",
+		Name:        "mstake",
+		Symbol:      "mstake",
 		DenomUnits: []DenomUnit{
 			{
 				Denom:    "stake",


### PR DESCRIPTION
Since cosmos-sdk 0.43, it is possible to specify "name" and "symbol" for coins metadata.

For "future" erc20 contract deployed by the bridge, I think it would make more sense to enforce the "name" and "symbol" to match the coin "name" and "symbol" instead of using the display field


Ref https://github.com/PeggyJV/gravity-bridge/pull/411