### PR TITLE
Problem: there is no invariant check to enforce the supply of tokens waiting to be transferred to Ethereum

### DIFF
--- a/module/x/gravity/keeper/batch.go
+++ b/module/x/gravity/keeper/batch.go
@@ -84,6 +84,20 @@ func (k Keeper) batchTxExecuted(ctx sdk.Context, tokenContract common.Address, n
 		}
 		return false
 	})
+
+	// burn the amount for non cosmos originated asset
+	isCosmosOriginated, denom := k.ERC20ToDenomLookup(ctx, common.HexToAddress(batchTx.TokenContract))
+	if !isCosmosOriginated {
+		totalToBurn := sdk.NewInt(0)
+		for _, tx := range batchTx.Transactions {
+			totalToBurn = totalToBurn.Add(tx.Erc20Token.Amount.Add(tx.Erc20Fee.Amount))
+		}
+		burnVouchers := sdk.NewCoins(sdk.NewCoin(denom, totalToBurn))
+		if err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, burnVouchers); err != nil {
+			panic(err)
+		}
+	}
+
 	k.DeleteOutgoingTx(ctx, batchTx.GetStoreIndex())
 }
 

--- a/module/x/gravity/keeper/batch.go
+++ b/module/x/gravity/keeper/batch.go
@@ -91,6 +91,11 @@ func (k Keeper) batchTxExecuted(ctx sdk.Context, tokenContract common.Address, n
 	if !isCosmosOriginated {
 		totalToBurn := sdk.NewInt(0)
 		for _, tx := range batchTx.Transactions {
+			// sanity check
+			if tx.Erc20Token.Contract != batchTx.TokenContract || tx.Erc20Fee.Contract != batchTx.TokenContract {
+				// should panic here as something is probably wrong
+				panic("detected invalid batch, contains tx with different contract address")
+			}
 			totalToBurn = totalToBurn.Add(tx.Erc20Token.Amount.Add(tx.Erc20Fee.Amount))
 		}
 		burnVouchers := sdk.NewCoins(sdk.NewCoin(denom, totalToBurn))

--- a/module/x/gravity/keeper/batch.go
+++ b/module/x/gravity/keeper/batch.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"encoding/binary"
 	"fmt"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -67,13 +68,13 @@ func (k Keeper) BuildBatchTx(ctx sdk.Context, contractAddress common.Address, ma
 
 // batchTxExecuted is run when the Cosmos chain detects that a batch has been executed on Ethereum
 // It deletes all the transactions in the batch, then cancels all earlier batches
-func (k Keeper) batchTxExecuted(ctx sdk.Context, tokenContract common.Address, nonce uint64) {
+func (k Keeper) batchTxExecuted(ctx sdk.Context, tokenContract common.Address, nonce uint64) error {
 	otx := k.GetOutgoingTx(ctx, types.MakeBatchTxKey(tokenContract, nonce))
 	if otx == nil {
 		k.Logger(ctx).Error("Failed to clean batches",
 			"token contract", tokenContract.Hex(),
 			"nonce", nonce)
-		return
+		return nil
 	}
 	batchTx, _ := otx.(*types.BatchTx)
 	k.IterateOutgoingTxsByType(ctx, types.BatchTxPrefixByte, func(key []byte, otx types.OutgoingTx) bool {
@@ -94,11 +95,12 @@ func (k Keeper) batchTxExecuted(ctx sdk.Context, tokenContract common.Address, n
 		}
 		burnVouchers := sdk.NewCoins(sdk.NewCoin(denom, totalToBurn))
 		if err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, burnVouchers); err != nil {
-			panic(err)
+			return sdkerrors.Wrapf(err, "burn vouchers coins: %s", burnVouchers)
 		}
 	}
 
 	k.DeleteOutgoingTx(ctx, batchTx.GetStoreIndex())
+	return nil
 }
 
 // getBatchFeesByTokenType gets the fees the next batch of a given token type would

--- a/module/x/gravity/keeper/batch.go
+++ b/module/x/gravity/keeper/batch.go
@@ -93,8 +93,7 @@ func (k Keeper) batchTxExecuted(ctx sdk.Context, tokenContract common.Address, n
 		for _, tx := range batchTx.Transactions {
 			// sanity check
 			if tx.Erc20Token.Contract != batchTx.TokenContract || tx.Erc20Fee.Contract != batchTx.TokenContract {
-				// should panic here as something is probably wrong
-				panic("detected invalid batch, contains tx with different contract address")
+				return sdkerrors.Wrapf(types.ErrInvalid, "detected invalid batch, contains tx with different contract address")
 			}
 			totalToBurn = totalToBurn.Add(tx.Erc20Token.Amount.Add(tx.Erc20Fee.Amount))
 		}

--- a/module/x/gravity/keeper/ethereum_event_handler.go
+++ b/module/x/gravity/keeper/ethereum_event_handler.go
@@ -54,7 +54,9 @@ func (k Keeper) Handle(ctx sdk.Context, eve types.EthereumEvent) (err error) {
 		return nil
 
 	case *types.BatchExecutedEvent:
-		k.batchTxExecuted(ctx, common.HexToAddress(event.TokenContract), event.BatchNonce)
+		if err := k.batchTxExecuted(ctx, common.HexToAddress(event.TokenContract), event.BatchNonce); err != nil {
+		return err
+		}
 		k.AfterBatchExecutedEvent(ctx, *event)
 		return nil
 

--- a/module/x/gravity/keeper/ethereum_event_handler.go
+++ b/module/x/gravity/keeper/ethereum_event_handler.go
@@ -55,7 +55,7 @@ func (k Keeper) Handle(ctx sdk.Context, eve types.EthereumEvent) (err error) {
 
 	case *types.BatchExecutedEvent:
 		if err := k.batchTxExecuted(ctx, common.HexToAddress(event.TokenContract), event.BatchNonce); err != nil {
-		return err
+			return err
 		}
 		k.AfterBatchExecutedEvent(ctx, *event)
 		return nil

--- a/module/x/gravity/keeper/ethereum_event_handler.go
+++ b/module/x/gravity/keeper/ethereum_event_handler.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"fmt"
 	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -62,7 +63,15 @@ func (k Keeper) Handle(ctx sdk.Context, eve types.EthereumEvent) (err error) {
 
 	case *types.ERC20DeployedEvent:
 		if err := k.verifyERC20DeployedEvent(ctx, event); err != nil {
-			return err
+			// log the error and return nil, otherwise the bridge will be desactivated
+			k.Logger(ctx).Error(
+				"verify erc20 deployed event failed",
+				"cause", err.Error(),
+				"event type", fmt.Sprintf("%T", event),
+				"id", types.MakeEthereumEventVoteRecordKey(event.GetEventNonce(), event.Hash()),
+				"nonce", fmt.Sprint(event.GetEventNonce()),
+			)
+			return nil
 		}
 
 		// add to denom-erc20 mapping

--- a/module/x/gravity/keeper/ethereum_event_vote.go
+++ b/module/x/gravity/keeper/ethereum_event_vote.go
@@ -119,9 +119,11 @@ func (k Keeper) processEthereumEvent(ctx sdk.Context, event types.EthereumEvent)
 	// then execute in a new Tx so that we can store state on failure
 	xCtx, commit := ctx.CacheContext()
 	if err := k.Handle(xCtx, event); err != nil { // execute with a transient storage
-		// If the attestation fails, something has gone wrong and we can't recover it. Log and move on
+		// If the attestation fails, something has gone wrong and we can't recover it. Disable the bridge,
+		// log the error and move on
 		// The attestation will still be marked "Observed", and validators can still be slashed for not
 		// having voted for it.
+		k.disableBridge(ctx)
 		k.Logger(ctx).Error(
 			"ethereum event vote record failed",
 			"cause", err.Error(),

--- a/module/x/gravity/keeper/invariants.go
+++ b/module/x/gravity/keeper/invariants.go
@@ -1,0 +1,114 @@
+package keeper
+
+import (
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	accType "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/peggyjv/gravity-bridge/module/v2/x/gravity/types"
+)
+
+// TODO: Add any future invariants here
+// TODO: (see the sdk docs for more info https://docs.cosmos.network/master/building-modules/invariants.html)
+func AllInvariants(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		return ModuleBalanceInvariant(k)(ctx)
+
+		// Example additional invariants
+		//  res, stop := FutureInvariant(k)(ctx)
+		//	if stop {
+		//		return res, stop
+		//	}
+		//
+		//	return AnotherFutureInvariant(k)(ctx)
+	}
+}
+
+// ModuleBalanceInvariant checks that the module account's balance is equal to the balance of unbatched transactions and unobserved batches
+// Note that the returned bool should be true if there is an error, e.g. an unexpected module balance
+func ModuleBalanceInvariant(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		modAcc := accType.NewModuleAddress(types.ModuleName)
+		actualBals := k.bankKeeper.GetAllBalances(ctx, modAcc)
+		expectedBals := make(map[string]*sdk.Int, len(actualBals)) // Collect balances by contract
+		for _, v := range actualBals {
+			newInt := sdk.NewInt(0)
+			expectedBals[v.Denom] = &newInt
+		}
+		expectedBals = sumUnconfirmedBatchModuleBalances(ctx, k, expectedBals)
+		expectedBals = sumUnbatchedSendToEthereumsModuleBalances(ctx, k, expectedBals)
+
+		// Compare actual vs expected balances
+		for _, actual := range actualBals {
+			denom := actual.GetDenom()
+			cosmosOriginated, _, err := k.DenomToERC20Lookup(ctx, denom)
+			if err != nil {
+				// Here we do not return because a user could halt the chain by gifting gravity a cosmos asset with no erc20 repr
+				ctx.Logger().Error("Unexpected gravity module balance of cosmos-originated asset with no erc20 representation", "asset", denom)
+				continue
+			}
+			expected, ok := expectedBals[denom]
+			if !ok {
+				return fmt.Sprint("Could not find expected balance for actual module balance of ", actual), true
+			}
+
+			if cosmosOriginated { // Cosmos originated mismatched balance
+				// We cannot make any assertions about cosmosOriginated assets because we do not have enough information.
+				// There is no index of denom => amount bridged, which would force us to parse all logs in existence
+			} else if !actual.Amount.Equal(*expected) { // Eth originated mismatched balance
+				return fmt.Sprint("Mismatched balance of eth-originated ", denom, ": actual balance ", actual.Amount, " != expected balance ", expected), true
+			}
+		}
+		return "", false
+	}
+}
+
+// sumUnconfirmedBatchModuleBalances calculate the value the module should have stored due to unconfirmed batches
+func sumUnconfirmedBatchModuleBalances(ctx sdk.Context, k Keeper, expectedBals map[string]*sdk.Int) map[string]*sdk.Int {
+	k.IterateOutgoingTxsByType(ctx, types.BatchTxPrefixByte, func(key []byte, otx types.OutgoingTx) bool {
+		batchTotal := sdk.NewInt(0)
+		// Collect the send amount + fee amount for each tx
+		batch, _ := otx.(*types.BatchTx)
+		for _, tx := range batch.Transactions {
+			newTotal := batchTotal.Add(tx.Erc20Token.Amount.Add(tx.Erc20Fee.Amount))
+			batchTotal = newTotal
+		}
+		contract := batch.TokenContract
+		_, denom := k.ERC20ToDenomLookup(ctx, common.HexToAddress(contract))
+		// Add the batch total to the contract counter
+		_, ok := expectedBals[denom]
+		if !ok {
+			zero := sdk.ZeroInt()
+			expectedBals[denom] = &zero
+		}
+
+		*expectedBals[denom] = expectedBals[denom].Add(batchTotal)
+
+		return false // continue iterating
+	})
+
+	return expectedBals
+}
+
+// sumUnbatchedSendToEthereumsModuleBalances calculates the value the module should have stored due to unbatched txs
+func sumUnbatchedSendToEthereumsModuleBalances(ctx sdk.Context, k Keeper, expectedBals map[string]*sdk.Int) map[string]*sdk.Int {
+	// It is also given the balance of all unbatched txs in the pool
+	k.IterateUnbatchedSendToEthereums(ctx, func(ste *types.SendToEthereum) bool {
+		contract := ste.Erc20Token.Contract
+		_, denom := k.ERC20ToDenomLookup(ctx, common.HexToAddress(contract))
+
+		// Collect the send amount + fee amount for each tx
+		txTotal := ste.Erc20Token.Amount.Add(ste.Erc20Fee.Amount)
+		_, ok := expectedBals[denom]
+		if !ok {
+			zero := sdk.ZeroInt()
+			expectedBals[denom] = &zero
+		}
+		*expectedBals[denom] = expectedBals[denom].Add(txTotal)
+
+		return false // continue iterating
+	})
+
+	return expectedBals
+}

--- a/module/x/gravity/keeper/invariants.go
+++ b/module/x/gravity/keeper/invariants.go
@@ -2,10 +2,9 @@ package keeper
 
 import (
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	accType "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/peggyjv/gravity-bridge/module/v2/x/gravity/types"
 )
 
@@ -71,8 +70,7 @@ func sumUnconfirmedBatchModuleBalances(ctx sdk.Context, k Keeper, expectedBals m
 		// Collect the send amount + fee amount for each tx
 		batch, _ := otx.(*types.BatchTx)
 		for _, tx := range batch.Transactions {
-			newTotal := batchTotal.Add(tx.Erc20Token.Amount.Add(tx.Erc20Fee.Amount))
-			batchTotal = newTotal
+			batchTotal = batchTotal.Add(tx.Erc20Token.Amount.Add(tx.Erc20Fee.Amount))
 		}
 		contract := batch.TokenContract
 		_, denom := k.ERC20ToDenomLookup(ctx, common.HexToAddress(contract))

--- a/module/x/gravity/keeper/invariants_test.go
+++ b/module/x/gravity/keeper/invariants_test.go
@@ -22,8 +22,7 @@ func TestModuleBalanceUnbatchedTxs(t *testing.T) {
 		myTokenContractAddr = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5")
 		myTokenDenom        = "gravity0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5"
 	)
-
-	input.GravityKeeper.setCosmosOriginatedDenomToERC20(ctx, myTokenDenom, myTokenContractAddr)
+	
 	// mint some voucher first
 	voucher := sdk.NewCoin(myTokenDenom, sdk.NewInt(99999))
 	allVouchers := sdk.Coins{voucher}
@@ -57,6 +56,14 @@ func TestModuleBalanceUnbatchedTxs(t *testing.T) {
 	// Remove one of the transactions
 	err = input.GravityKeeper.cancelSendToEthereum(ctx, 1, mySender.String())
 	require.NoError(t, err)
+	checkInvariant(t, ctx, input.GravityKeeper, true)
+
+	// Build batch and check
+	batch := input.GravityKeeper.BuildBatchTx(ctx, myTokenContractAddr, 100)
+	checkInvariant(t, ctx, input.GravityKeeper, true)
+
+	// Execute batch and check
+	input.GravityKeeper.batchTxExecuted(ctx, myTokenContractAddr, batch.BatchNonce)
 	checkInvariant(t, ctx, input.GravityKeeper, true)
 
 	// Ensure an error is returned for a mismatched balance

--- a/module/x/gravity/keeper/invariants_test.go
+++ b/module/x/gravity/keeper/invariants_test.go
@@ -1,0 +1,84 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/peggyjv/gravity-bridge/module/v2/x/gravity/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// Tests that the gravity module's balance is accounted for with unbatched txs, including tx cancellation
+func TestModuleBalanceUnbatchedTxs(t *testing.T) {
+	////////////////// SETUP //////////////////
+	input := CreateTestEnv(t)
+	defer func() { input.Context.Logger().Info("Asserting invariants at test end"); input.AssertInvariants() }()
+
+	ctx := input.Context
+	var (
+		mySender, _         = sdk.AccAddressFromBech32("gravity1ahx7f8wyertuus9r20284ej0asrs085ceqtfnm")
+		myReceiver          = "0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7"
+		myTokenContractAddr = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5")
+		myTokenDenom        = "gravity0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5"
+	)
+
+	input.GravityKeeper.setCosmosOriginatedDenomToERC20(ctx, myTokenDenom, myTokenContractAddr)
+	// mint some voucher first
+	voucher := sdk.NewCoin(myTokenDenom, sdk.NewInt(99999))
+	allVouchers := sdk.Coins{voucher}
+	err := input.BankKeeper.MintCoins(ctx, types.ModuleName, allVouchers)
+	require.NoError(t, err)
+	// set senders balance
+	input.AccountKeeper.NewAccountWithAddress(ctx, mySender)
+	err = input.BankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, mySender, allVouchers)
+	require.NoError(t, err)
+
+	////////////////// EXECUTE //////////////////
+	// Check the invariant without any transactions
+	checkInvariant(t, ctx, input.GravityKeeper, true)
+
+	// Create some unbatched transactions
+	for i, v := range []uint64{2, 3, 2, 1} {
+		input.GravityKeeper.createSendToEthereum(
+			ctx,
+			mySender,
+			myReceiver,
+			sdk.NewCoin(myTokenDenom, sdk.NewInt(int64(i+100))),
+			sdk.NewCoin(myTokenDenom, sdk.NewIntFromUint64(v)))
+		// Should create:
+		// 1: amount 100, fee 2
+		// 2: amount 101, fee 3
+		// 3: amount 102, fee 2
+		// 4: amount 103, fee 1
+	}
+	checkInvariant(t, ctx, input.GravityKeeper, true)
+
+	// Remove one of the transactions
+	err = input.GravityKeeper.cancelSendToEthereum(ctx, 1, mySender.String())
+	require.NoError(t, err)
+	checkInvariant(t, ctx, input.GravityKeeper, true)
+
+	// Ensure an error is returned for a mismatched balance
+	oneVoucher := sdk.NewCoin(myTokenDenom, sdk.NewInt(2))
+	checkImbalancedModule(t, ctx, input.GravityKeeper, input.BankKeeper, mySender, sdk.NewCoins(oneVoucher))
+}
+
+func checkInvariant(t *testing.T, ctx sdk.Context, k Keeper, succeed bool) {
+	res, ok := ModuleBalanceInvariant(k)(ctx)
+	if succeed {
+		require.False(t, ok, "Invariant should have returned false")
+		require.Empty(t, res, "Invariant should have returned no message")
+	} else {
+		require.True(t, ok, "Invariant should have returned true")
+		require.NotEmpty(t, res, "Invariant should have returned a message")
+	}
+}
+
+func checkImbalancedModule(t *testing.T, ctx sdk.Context, gravityKeeper Keeper, bankKeeper bankkeeper.BaseKeeper, sender sdk.AccAddress, coins sdk.Coins) {
+	// Imbalance the module
+	bankKeeper.SendCoinsFromAccountToModule(ctx, sender, types.ModuleName, coins)
+	checkInvariant(t, ctx, gravityKeeper, false)
+	// Rebalance the module
+	bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, sender, coins)
+}

--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -726,3 +726,10 @@ func (k Keeper) MigrateGravityContract(ctx sdk.Context, newBridgeAddress string,
 	params.BridgeEthereumAddress = newBridgeAddress
 	k.SetParams(ctx, params)
 }
+
+// getBridgeChainID returns the chain id of the ETH chain we are running against
+func (k Keeper) disableBridge(ctx sdk.Context) {
+	gravityParam := k.GetParams(ctx)
+	gravityParam.BridgeActive = false
+	k.SetParams(ctx, gravityParam)
+}

--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -732,4 +732,6 @@ func (k Keeper) disableBridge(ctx sdk.Context) {
 	gravityParam := k.GetParams(ctx)
 	gravityParam.BridgeActive = false
 	k.SetParams(ctx, gravityParam)
+
+	k.Logger(ctx).Info("BridgeActivate is set to false")
 }

--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -727,7 +727,7 @@ func (k Keeper) MigrateGravityContract(ctx sdk.Context, newBridgeAddress string,
 	k.SetParams(ctx, params)
 }
 
-// getBridgeChainID returns the chain id of the ETH chain we are running against
+// disableBridge disable the bridge processing all outgoing and ingoing transactions
 func (k Keeper) disableBridge(ctx sdk.Context) {
 	gravityParam := k.GetParams(ctx)
 	gravityParam.BridgeActive = false

--- a/module/x/gravity/keeper/test_common.go
+++ b/module/x/gravity/keeper/test_common.go
@@ -231,6 +231,20 @@ func (input TestInput) AddBalanceToBank(ctx sdk.Context, addr sdk.AccAddress, ba
 	return fundAccount(ctx, input.BankKeeper, addr, balances)
 }
 
+// AssertInvariants tests each modules invariants individually, this is easier than
+// dealing with all the init required to get the crisis keeper working properly by
+// running appModuleBasic for every module and allowing them to register their invariants
+func (t TestInput) AssertInvariants() {
+	gravInvariantFunc := AllInvariants(t.GravityKeeper)
+	invariantStr, invariantViolated := gravInvariantFunc(t.Context)
+	if invariantViolated {
+		panic(invariantStr)
+	}
+
+	// TODO: add the other module invariants
+	t.Context.Logger().Info("All invariants successful")
+}
+
 // SetupFiveValChain does all the initialization for a 5 Validator chain using the keys here
 func SetupFiveValChain(t *testing.T) (TestInput, sdk.Context) {
 	t.Helper()

--- a/module/x/gravity/module.go
+++ b/module/x/gravity/module.go
@@ -109,8 +109,7 @@ func (AppModule) ConsensusVersion() uint64 {
 
 // RegisterInvariants implements app module
 func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
-	// TODO: make some invariants in the gravity module to ensure that
-	// coins aren't being fraudlently minted etc...
+	ir.RegisterRoute(types.ModuleName, "module-balance", keeper.ModuleBalanceInvariant(am.keeper))
 }
 
 // Route implements app module


### PR DESCRIPTION
Fix security audit item https://github.com/PeggyJV/gravity-bridge/issues/246

For non cosmos originated token :

- Remove the burn at "SendToEthereum" msg-
- Remove the mint at "CancelSendToEthereum" msg
- Add the burn after "BatchTxExecuted"
- Create an invariant for non cosmos originated token that check that for each type of tokens
module amount = sum( unbatchedOutgoingTxs + batchOutgoings amount)

Ref https://github.com/PeggyJV/gravity-bridge/pull/393
