### PR TITLE
Problem: keeper setParam is private

### DIFF
--- a/module/x/gravity/keeper/genesis.go
+++ b/module/x/gravity/keeper/genesis.go
@@ -12,7 +12,7 @@ import (
 
 // InitGenesis starts a chain from a genesis state
 func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) {
-	k.setParams(ctx, *data.Params)
+	k.SetParams(ctx, *data.Params)
 
 	// reset pool transactions in state
 	for _, tx := range data.UnbatchedSendToEthereumTxs {

--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -334,8 +334,8 @@ func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
 	return
 }
 
-// setParams sets the parameters in the store
-func (k Keeper) setParams(ctx sdk.Context, ps types.Params) {
+// SetParams sets the parameters in the store
+func (k Keeper) SetParams(ctx sdk.Context, ps types.Params) {
 	k.paramSpace.SetParamSet(ctx, &ps)
 }
 
@@ -724,5 +724,5 @@ func (k Keeper) MigrateGravityContract(ctx sdk.Context, newBridgeAddress string,
 	// Update the bridge contract address
 	params := k.GetParams(ctx)
 	params.BridgeEthereumAddress = newBridgeAddress
-	k.setParams(ctx, params)
+	k.SetParams(ctx, params)
 }

--- a/module/x/gravity/keeper/test_common.go
+++ b/module/x/gravity/keeper/test_common.go
@@ -445,7 +445,7 @@ func CreateTestEnv(t *testing.T) TestInput {
 		),
 	)
 
-	k.setParams(ctx, TestingGravityParams)
+	k.SetParams(ctx, TestingGravityParams)
 
 	return TestInput{
 		GravityKeeper:   k,


### PR DESCRIPTION
Need to use it within the upgrade handler to setup the correct genesis param

Solution: make it public