### PR TITLE
Problem: old valset signatures are not deleted correctly 

### DIFF
--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -107,6 +107,9 @@ func pruneSignerSetTxs(ctx sdk.Context, k keeper.Keeper) {
 		earliestToPrune := currentBlock - params.SignedSignerSetTxsWindow
 		for _, set := range k.GetSignerSetTxs(ctx) {
 			if set.Nonce < lastObserved.Nonce && set.Height < earliestToPrune {
+				// delete the signatures
+				k.DeleteEthereumSignatures(ctx, set)
+				// delete the outgoing signer set tx
 				k.DeleteOutgoingTx(ctx, set.GetStoreIndex())
 			}
 		}

--- a/module/x/gravity/abci_test.go
+++ b/module/x/gravity/abci_test.go
@@ -2,6 +2,7 @@ package gravity_test
 
 import (
 	"fmt"
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
 	"testing"
 	"time"
 
@@ -30,6 +31,56 @@ func TestSignerSetTxCreationIfNotAvailable(t *testing.T) {
 	_, ok := otx.(*types.SignerSetTx)
 	require.True(t, ok)
 	require.True(t, len(gravityKeeper.GetSignerSetTxs(ctx)) == 1)
+}
+
+func TestPruneSignerSetTxs(t *testing.T) {
+	input, ctx := keeper.SetupFiveValChain(t)
+	gravityKeeper := input.GravityKeeper
+	params := input.GravityKeeper.GetParams(ctx)
+
+	// BeginBlocker should set a new validator set if not available
+	gravity.BeginBlocker(ctx, gravityKeeper)
+	otx := gravityKeeper.GetOutgoingTx(ctx, types.MakeSignerSetTxKey(1))
+	require.NotNil(t, otx)
+	signerSetTx, ok := otx.(*types.SignerSetTx)
+	require.True(t, ok)
+	require.True(t, len(gravityKeeper.GetSignerSetTxs(ctx)) == 1)
+
+	// Add a signature
+	ethPrivKey, _ := ethCrypto.GenerateKey()
+	ethAddr := ethCrypto.PubkeyToAddress(ethPrivKey.PublicKey)
+	orcAddr, _ := sdk.AccAddressFromBech32("cosmos1dg55rtevlfxh46w88yjpdd08sqhh5cc3xhkcej")
+	valAddr := sdk.ValAddress(orcAddr)
+
+	gravityId := params.GravityId
+	checkpoint := signerSetTx.GetCheckpoint([]byte(gravityId))
+	signature, _ := types.NewEthereumSignature(checkpoint, ethPrivKey)
+	signerSetTxConfirmation := &types.SignerSetTxConfirmation{
+		SignerSetNonce: signerSetTx.Nonce,
+		EthereumSigner: ethAddr.Hex(),
+		Signature:      signature,
+	}
+	gravityKeeper.SetEthereumSignature(ctx, signerSetTxConfirmation, valAddr)
+	// Check that signature exist
+	signatures := gravityKeeper.GetEthereumSignatures(ctx, types.MakeSignerSetTxKey(1))
+	require.Equal(t, 1, len(signatures))
+
+	// Handle outgoing tx event
+	gravityKeeper.Handle(ctx, &types.SignerSetTxExecutedEvent{
+		EventNonce:       1,
+		SignerSetTxNonce: signerSetTx.Nonce + 1,
+	})
+
+	// Define new height for the pruning to happen
+	prunedHeight := uint64(ctx.BlockHeight()) + (params.SignedSignerSetTxsWindow + 1)
+	newCtx := ctx.WithBlockHeight(int64(prunedHeight))
+	// Prune the valset
+	gravity.BeginBlocker(newCtx, gravityKeeper)
+	otx = gravityKeeper.GetOutgoingTx(newCtx, types.MakeSignerSetTxKey(1))
+	require.Nil(t, otx)
+	// Check that signatures are pruned as well
+	signatures = gravityKeeper.GetEthereumSignatures(newCtx, types.MakeSignerSetTxKey(1))
+	require.Equal(t, 0, len(signatures))
 }
 
 func TestSignerSetTxCreationUponUnbonding(t *testing.T) {

--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -643,6 +643,17 @@ func (k Keeper) IterateEthereumHeightVotes(ctx sdk.Context, cb func(val sdk.ValA
 	}
 }
 
+// DeleteEthereumSignatures deletes the ethereum signatures for a specific outgoing tx
+func (k Keeper) DeleteEthereumSignatures(ctx sdk.Context, otx types.OutgoingTx) {
+	prefixStoreSig := prefix.NewStore(ctx.KVStore(k.storeKey), append([]byte{types.EthereumSignatureKey}, otx.GetStoreIndex()...))
+	iterSig := prefixStoreSig.Iterator(nil, nil)
+	defer iterSig.Close()
+
+	for ; iterSig.Valid(); iterSig.Next() {
+		prefixStoreSig.Delete(iterSig.Key())
+	}
+}
+
 /////////////////
 // MIGRATE     //
 /////////////////
@@ -666,13 +677,7 @@ func (k Keeper) MigrateGravityContract(ctx sdk.Context, newBridgeAddress string,
 			panic(err)
 		}
 		// Delete any partial Eth Signatures handging around
-		prefixStoreSig := prefix.NewStore(ctx.KVStore(k.storeKey), append([]byte{types.EthereumSignatureKey}, otx.GetStoreIndex()...))
-		iterSig := prefixStoreSig.Iterator(nil, nil)
-		defer iterSig.Close()
-
-		for ; iterSig.Valid(); iterSig.Next() {
-			prefixStoreSig.Delete(iterSig.Key())
-		}
+		k.DeleteEthereumSignatures(ctx, otx)
 
 		prefixStoreOtx.Delete(iterOtx.Key())
 	}


### PR DESCRIPTION
This fix the issue we encounter in the migration function.

Because the signatures were not deleted along the outgoing tx, we end up having inconsistent state. 

Since the outgoing tx were deleted, but not the signature, during the migration handler, some signatures were existing but couldnt be detected through the iterator.

After the signs window period, both the outgoing tx and signatures are not needed anymore so we can delete them safely.

https://github.com/crypto-org-chain/gravity-bridge/issues/112