### PR TITLE
Problem: only one attestation can be processed per block

### DIFF
--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -170,7 +170,14 @@ func eventVoteRecordPruneAndTally(ctx sdk.Context, k keeper.Keeper) {
 			// it will be skipped. The same will happen for every nonce after that.
 			if nonce == lastNonce+1 {
 				k.TryEventVoteRecord(ctx, att)
+				// update the lastNonce in case TryEventVoteRecord succeed to allow the next attestation
+				// to be processed
+				lastNonce = uint64(k.GetLastObservedEventNonce(ctx))
 			}
+		}
+
+		if nonce > lastNonce+1 {
+			break
 		}
 	}
 }


### PR DESCRIPTION
Found that the tps was very low during the stress test.

The reason is that we introduced a bug previously that prevent more than one attestation to be processed in a block. 

This fix should resolve the issue