### PR TITLE
Problem: MigrateGravityContract does not delete all ethereum signatures

### DIFF
--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -667,17 +667,24 @@ func (k Keeper) MigrateGravityContract(ctx sdk.Context, newBridgeAddress string,
 	prefixStoreOtx := prefix.NewStore(ctx.KVStore(k.storeKey), []byte{types.OutgoingTxKey})
 	iterOtx := prefixStoreOtx.ReverseIterator(nil, nil)
 	defer iterOtx.Close()
+	var oxtToDeleteKeys [][]byte
 	for ; iterOtx.Valid(); iterOtx.Next() {
-		prefixStoreOtx.Delete(iterOtx.Key())
+		oxtToDeleteKeys = append(oxtToDeleteKeys, iterOtx.Key())
+	}
+	for _, key := range oxtToDeleteKeys {
+		prefixStoreOtx.Delete(key)
 	}
 
 	// Delete all ethereum signature for all Outgoing TXs.
 	prefixStoreSig := prefix.NewStore(ctx.KVStore(k.storeKey), []byte{types.EthereumSignatureKey})
 	iterSig := prefixStoreSig.Iterator(nil, nil)
 	defer iterSig.Close()
-
+	var sigToDeleteKeys [][]byte
 	for ; iterSig.Valid(); iterSig.Next() {
-		prefixStoreSig.Delete(iterSig.Key())
+		sigToDeleteKeys = append(sigToDeleteKeys, iterSig.Key())
+	}
+	for _, key := range sigToDeleteKeys {
+		prefixStoreSig.Delete(key)
 	}
 
 	// Reset the last observed signer set nonce
@@ -704,8 +711,12 @@ func (k Keeper) MigrateGravityContract(ctx sdk.Context, newBridgeAddress string,
 	prefixStoreEthereumEvent := prefix.NewStore(ctx.KVStore(k.storeKey), []byte{types.EthereumEventVoteRecordKey})
 	iterEvent := prefixStoreEthereumEvent.Iterator(nil, nil)
 	defer iterEvent.Close()
+	var eventToDeleteKeys [][]byte
 	for ; iterEvent.Valid(); iterEvent.Next() {
-		prefixStoreEthereumEvent.Delete(iterEvent.Key())
+		eventToDeleteKeys = append(eventToDeleteKeys, iterEvent.Key())
+	}
+	for _, key := range eventToDeleteKeys {
+		prefixStoreEthereumEvent.Delete(key)
 	}
 
 	// Set the Last oberved Ethereum Blockheight to zero

--- a/module/x/gravity/keeper/keeper_test.go
+++ b/module/x/gravity/keeper/keeper_test.go
@@ -551,6 +551,28 @@ func TestKeeper_Migration(t *testing.T) {
 		},
 	}
 
+	// assume it is an expired event
+	stce2 := &types.SendToCosmosEvent{
+		EventNonce:     3,
+		TokenContract:  EthAddrs[0].Hex(),
+		EthereumSender: EthAddrs[0].Hex(),
+		CosmosReceiver: AccAddrs[0].String(),
+		EthereumHeight: 10,
+		Amount:         sdk.NewInt(1000000),
+	}
+	stcea2, err := types.PackEvent(stce2)
+	require.NoError(t, err)
+
+	evr21 := &types.EthereumEventVoteRecord{
+		Event: stcea2,
+		Votes: []string{
+			ValAddrs[0].String(),
+			ValAddrs[1].String(),
+			ValAddrs[2].String(),
+		},
+		Accepted: false,
+	}
+
 	//Put an outgoing transaction into the system
 
 	var (
@@ -585,6 +607,10 @@ func TestKeeper_Migration(t *testing.T) {
 	gk.setEthereumEventVoteRecord(ctx, stce.GetEventNonce(), stce.Hash(), evr)
 	gk.setLastObservedEventNonce(ctx, stce.GetEventNonce())
 	gk.setEthereumEventVoteRecord(ctx, cctxe.GetEventNonce(), cctxe.Hash(), evr2)
+	gk.setLastObservedEventNonce(ctx, cctxe.GetEventNonce())
+
+	// set only the event vote record of the expired event to simulate the bug from (#113))
+	gk.setEthereumEventVoteRecord(ctx, stce2.GetEventNonce(), stce2.Hash(), evr21)
 	gk.setLastObservedEventNonce(ctx, cctxe.GetEventNonce())
 
 	stored := gk.GetEthereumEventVoteRecord(ctx, stce.GetEventNonce(), stce.Hash())
@@ -642,6 +668,9 @@ func TestKeeper_Migration(t *testing.T) {
 
 	stored2AfterMigrate := gk.GetEthereumEventVoteRecord(ctx, cctxe.GetEventNonce(), cctxe.Hash())
 	require.Nil(t, stored2AfterMigrate)
+
+	stored3AfterMigrate := gk.GetEthereumEventVoteRecord(ctx, stce2.GetEventNonce(), stce2.Hash())
+	require.Nil(t, stored3AfterMigrate)
 
 	nonce2 := gk.GetLastObservedEventNonce(ctx)
 	require.Equal(t, uint64(0), nonce2)


### PR DESCRIPTION
The problem is caused  by a  bug fixed there 

https://github.com/crypto-org-chain/gravity-bridge/commit/25c2a2731694c4416e6bf711ecc794a67a1b42cc

The otx (outgoing tx) is deleted when expired but not the ethereum signature.

The migration function currently loop over the non-expired otx and delete the attached ethereum signature, but for the signature that is attached to an already expired otx, they cannot be found because the otx has been already deleted

So the solution is to loop over the whole prefix store and delete everything.



