### PR TITLE
Problem: migrate function does not reset properly validator nonce

### DIFF
--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -696,13 +696,11 @@ func (k Keeper) MigrateGravityContract(ctx sdk.Context, newBridgeAddress string,
 	// Reset all validators ethereum event nonce to zero
 	delegateKeys := k.getDelegateKeys(ctx)
 	for _, delegateKey := range delegateKeys {
-		if len(delegateKey.ValidatorAddress) != 0 {
-			validator, err := sdk.ValAddressFromBech32(delegateKey.ValidatorAddress)
-			if err != nil {
-				panic(err)
-			}
-			k.setLastEventNonceByValidator(ctx, validator, 0)
+		validator, err := sdk.ValAddressFromBech32(delegateKey.ValidatorAddress)
+		if err != nil {
+			panic(err)
 		}
+		k.setLastEventNonceByValidator(ctx, validator, 0)
 	}
 
 	// Delete all Ethereum Events

--- a/module/x/gravity/keeper/keeper_test.go
+++ b/module/x/gravity/keeper/keeper_test.go
@@ -506,10 +506,8 @@ func TestKeeper_GetEthereumSignatures(t *testing.T) {
 }
 
 func TestKeeper_Migration(t *testing.T) {
-
-	input := CreateTestEnv(t)
+	input, ctx := SetupFiveValChain(t)
 	gk := input.GravityKeeper
-	ctx := input.Context
 
 	stce := &types.SendToCosmosEvent{
 		EventNonce:     1,
@@ -545,9 +543,9 @@ func TestKeeper_Migration(t *testing.T) {
 	evr2 := &types.EthereumEventVoteRecord{
 		Event: cctxea,
 		Votes: []string{
+			ValAddrs[1].String(),
 			ValAddrs[2].String(),
 			ValAddrs[3].String(),
-			ValAddrs[4].String(),
 		},
 	}
 
@@ -568,7 +566,7 @@ func TestKeeper_Migration(t *testing.T) {
 		Votes: []string{
 			ValAddrs[0].String(),
 			ValAddrs[1].String(),
-			ValAddrs[2].String(),
+			ValAddrs[3].String(),
 		},
 		Accepted: false,
 	}
@@ -675,6 +673,7 @@ func TestKeeper_Migration(t *testing.T) {
 	nonce2 := gk.GetLastObservedEventNonce(ctx)
 	require.Equal(t, uint64(0), nonce2)
 
+	// make sure all event nonce are reset. Even val5 which did not participate any votes
 	for _, val := range ValAddrs {
 		require.Equal(t, uint64(0), gk.getLastEventNonceByValidator(ctx, val))
 	}


### PR DESCRIPTION
Problem: To reset the state of each orchestrator (nonce), the current code loop over all the attestations voters and set their nonce to 0
Before https://github.com/crypto-org-chain/gravity-bridge/pull/75 we are keeping ALL the attestations in the state, but with the new improvement, we are keeping only the most recent one’s. 

Validator that miss to vote on the most recent attestation will be miss by the migrate function and their state will remains.

The solution is to change the code to get the list of validators and set their nonce to zero for each of them

