### PR TITLE
Problem: the command make e2e_build_images fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 e2e_build_images:
 	@docker build -t gravity:prebuilt -f module/Dockerfile module/
-	@docker build -t ethereum:prebuilt -f integration_tests/ethereum/Dockerfile integration_tests/ethereum/
+	@docker build -t ethereum:prebuilt -f integration_tests/ethereum/Dockerfile .
 	@docker build -t orchestrator:prebuilt -f orchestrator/Dockerfile orchestrator/
 
 


### PR DESCRIPTION
Solution: use root as context

Solve https://github.com/crypto-org-chain/gravity-bridge/issues/188