### PR TITLE
Problem: orchestrator cannot build

### DIFF
--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -1709,8 +1709,8 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7115eae4b8518967b8e737a3ef76025f2d007de7906d88c18f00b8bbfc70f51e"
 dependencies = [
- "prost 0.7.0",
- "prost-types 0.7.0",
+ "prost",
+ "prost-types",
  "tendermint-proto",
  "tonic",
 ]
@@ -1730,8 +1730,8 @@ dependencies = [
  "gravity_proto",
  "gravity_utils",
  "log",
- "prost 0.7.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "rand 0.8.5",
  "serde",
  "sha3 0.9.1",
@@ -1960,8 +1960,8 @@ dependencies = [
  "num-traits",
  "num256",
  "pbkdf2 0.11.0",
- "prost 0.7.0",
- "prost-types 0.7.0",
+ "prost",
+ "prost-types",
  "rand 0.8.5",
  "ripemd",
  "rust_decimal",
@@ -2758,7 +2758,7 @@ dependencies = [
  "orchestrator",
  "pkcs8",
  "proc-macro2",
- "prost 0.7.0",
+ "prost",
  "rand_core 0.6.4",
  "regex",
  "relayer",
@@ -2819,8 +2819,8 @@ version = "0.1.0"
 dependencies = [
  "bytes 1.3.0",
  "cosmos-sdk-proto",
- "prost 0.7.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "tonic",
 ]
 
@@ -2828,7 +2828,7 @@ dependencies = [
 name = "gravity_proto_build"
 version = "0.1.0"
 dependencies = [
- "prost 0.7.0",
+ "prost",
  "prost-build",
  "regex",
  "tempdir",
@@ -3291,15 +3291,6 @@ name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -4266,17 +4257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
  "bytes 1.3.0",
- "prost-derive 0.7.0",
-]
-
-[[package]]
-name = "prost"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
-dependencies = [
- "bytes 1.3.0",
- "prost-derive 0.8.0",
+ "prost-derive",
 ]
 
 [[package]]
@@ -4287,12 +4268,12 @@ checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
  "bytes 1.3.0",
  "heck 0.3.3",
- "itertools 0.9.0",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
- "prost 0.7.0",
- "prost-types 0.7.0",
+ "prost",
+ "prost-types",
  "tempfile",
  "which",
 ]
@@ -4304,20 +4285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -4330,17 +4298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
  "bytes 1.3.0",
- "prost 0.7.0",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
-dependencies = [
- "bytes 1.3.0",
- "prost 0.8.0",
+ "prost",
 ]
 
 [[package]]
@@ -5575,8 +5533,8 @@ dependencies = [
  "chrono",
  "num-derive",
  "num-traits",
- "prost 0.7.0",
- "prost-types 0.7.0",
+ "prost",
+ "prost-types",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -5970,8 +5928,8 @@ dependencies = [
  "hyper",
  "percent-encoding",
  "pin-project 1.0.12",
- "prost 0.7.0",
- "prost-derive 0.7.0",
+ "prost",
+ "prost-derive",
  "rustls-native-certs",
  "tokio 1.23.0",
  "tokio-rustls 0.22.0",

--- a/orchestrator/cosmos_gravity/Cargo.toml
+++ b/orchestrator/cosmos_gravity/Cargo.toml
@@ -23,7 +23,7 @@ web30 = "0.15.4"
 tonic = { version = "0.4.0", features = ["tls", "tls-roots"] }
 cosmos-sdk-proto = "0.6.3"
 prost = "0.7"
-prost-types = "0.8"
+prost-types = "0.7"
 bytes = "1"
 
 [dev-dependencies]

--- a/orchestrator/gravity_proto/Cargo.toml
+++ b/orchestrator/gravity_proto/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 prost = "0.7"
-prost-types = "0.8"
+prost-types = "0.7"
 bytes = "1"
 cosmos-sdk-proto = "0.6.3"
 tonic = "0.4"


### PR DESCRIPTION
Revert the dependency upgrade https://github.com/crypto-org-chain/gravity-bridge/pull/50 because it is breaking the build