### PR TITLE
Problem: wrong gogo/protobuf version is used

### DIFF
--- a/module/go.mod
+++ b/module/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cosmos/gogoproto v1.4.6
 	github.com/cosmos/ibc-go/v7 v7.0.0
 	github.com/ethereum/go-ethereum v1.10.26
-	github.com/gogo/protobuf v1.3.3
+	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
fix to [v1.3.2](https://github.com/gogo/protobuf/tree/v1.3.2) to avoid `go: github.com/gogo/protobuf@v1.3.3: reading github.com/gogo/protobuf/go.mod at revision v1.3.3: unknown revision v1.3.3`